### PR TITLE
Add mfcj625dw

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1659,6 +1659,12 @@
     githubId = 2245737;
     name = "Christopher Mark Poole";
   };
+  chuahou = {
+    email = "human+github@chuahou.dev";
+    github = "chuahou";
+    githubId = 12386805;
+    name = "Chua Hou";
+  };
   ciil = {
     email = "simon@lackerbauer.com";
     github = "ciil";

--- a/pkgs/misc/cups/drivers/mfcj625dwcupswrapper/default.nix
+++ b/pkgs/misc/cups/drivers/mfcj625dwcupswrapper/default.nix
@@ -1,0 +1,71 @@
+{ stdenv
+, fetchurl
+, makeWrapper
+
+  # lpr driver
+, mfcj625dwlpr
+
+  # runtime dependencies
+, coreutils
+, cups
+, gnused
+}:
+
+stdenv.mkDerivation rec {
+  pname = "mfcj625dwcupswrapper";
+  version = "3.0.0-1";
+
+  src = fetchurl {
+    url = "https://download.brother.com/welcome/dlf006812/${pname}-src-${version}.tar.gz";
+    sha256 = "0qjivraiy81vij5q4cm92ad4nc98p6xpqkxfqj3vk8xb35w7p68g";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ mfcj625dwlpr ];
+
+  patchPhase = ''
+    sed -i -e '26,304d' cupswrapper/cupswrappermfcj625dw
+    substituteInPlace cupswrapper/cupswrappermfcj625dw \
+        --replace "\$ppd_file_name" \
+          "$out/share/cups/model/brother_mfcj625dw_printer_en.ppd"
+  '';
+
+  buildPhase = ''
+    make -C brcupsconfig
+  '';
+
+  installPhase = ''
+    TGT_FOLDER=$out/opt/brother/Printers/mfcj625dw/cupswrapper
+    mkdir -p $TGT_FOLDER
+    cp brcupsconfig/brcupsconfpt1 $TGT_FOLDER
+    cp cupswrapper/cupswrappermfcj625dw $TGT_FOLDER
+    cp ppd/brother_mfcj625dw_printer_en.ppd $TGT_FOLDER
+    wrapProgram $TGT_FOLDER/cupswrappermfcj625dw \
+        --prefix PATH : ${stdenv.lib.makeBinPath [
+          coreutils
+          cups
+          gnused
+        ]}
+
+    mkdir -p $out/lib/cups/filter
+    ln -s ${mfcj625dwlpr}/lib/cups/filter/brother_lpdwrapper_mfcj625dw \
+        $out/lib/cups/filter/brother_lpdwrapper_mfcj625dw
+
+    mkdir -p $out/share/cups/model
+    ln -s $TGT_FOLDER/brother_mfcj625dw_printer_en.ppd \
+        $out/share/cups/model/brother_mfcj625dw_printer_en.ppd
+  '';
+
+  cleanPhase = ''
+    make -C brcupsconfig clean
+  '';
+
+  meta = {
+    description = "Brother MFC-J625DW CUPS wrapper driver";
+    homepage = "https://global.brother";
+    license = stdenv.lib.licenses.gpl2;
+    platforms = stdenv.lib.platforms.linux;
+    downloadPage = "https://support.brother.com/g/b/downloadlist.aspx?c=sg&lang=en&prod=mfcj625dw_all&os=128";
+    maintainers = stdenv.lib.maintainers.chuahou;
+  };
+}

--- a/pkgs/misc/cups/drivers/mfcj625dwlpr/default.nix
+++ b/pkgs/misc/cups/drivers/mfcj625dwlpr/default.nix
@@ -1,0 +1,122 @@
+{ lib
+, stdenv
+, fetchurl
+
+  # unpacking/patching
+, autoPatchelfHook
+, dpkg
+, makeWrapper
+, util-linux
+, xxd
+
+  # runtime dependencies
+, a2ps
+, coreutils
+, cups
+, file
+, ghostscript
+, gnused
+, runtimeShell
+}:
+
+# Explanation copied and modified from the sibling package 'mfcj6510dwlpr'.
+#
+# Why:
+# The executable "brprintconf_mfcj625dw" binary is looking for "/opt/brother/Printers/%s/inf/br%sfunc" and "/opt/brother/Printers/%s/inf/br%src".
+# Whereby, %s is printf(3) string substitution for stdin's arg0 (the command's own filename) from the 10th char forwards, as a runtime dependency.
+# e.g. Say the filename is "0123456789ABCDE", the runtime will be looking for /opt/brother/Printers/ABCDE/inf/brABCDEfunc.
+# Presumably, the binary was designed to be deployed under the filename "printconf_mfcj625dw", whereby it will search for "/opt/brother/Printers/mfcj625dw/inf/brmfcj625dwfunc".
+# For NixOS, we want to change the string to the store path of brmfcj625dwfunc and brmfcj625dwrc but we're faced with two complications:
+# 1. Too little room to specify the nix store path. We can't even take advantage of %s by renaming the file to the store path hash since the variable is too short and can't contain the whole hash.
+# 2. The binary needs the directory it's running from to be r/w.
+# What:
+# As such, we strip the path and substitution altogether, leaving only "brmfcj625dwfunc" and "brmfcj625dwrc", while filling the leftovers with nulls.
+# Fully null terminating the cstrings is necessary to keep the array the same size and preventing overflows.
+# We then use a shell script to link and execute the binary, func and rc files in a temporary directory.
+# How:
+# In the package, we dump the raw binary as a string of search-able hex values using hexdump. We execute the substitution with sed. We then convert the hex values back to binary form using xxd.
+# We also write a shell script that invoked "mktemp -d" to produce a r/w temporary directory and link what we need in the temporary directory.
+# Result:
+# The user can run brprintconf_mfcj625dw in the shell.
+
+stdenv.mkDerivation rec {
+  pname = "mfcj625dwlpr";
+  version = "3.0.1-1";
+
+  src = fetchurl {
+    url = "https://download.brother.com/welcome/dlf006606/${pname}-${version}.i386.deb";
+    sha256 = "1cv2ysw5shyipiq7zd5lq5cpb6isk97szlkfz3y8s4kl844vkm9l";
+  };
+
+  nativeBuildInputs = [ dpkg autoPatchelfHook makeWrapper ];
+  buildInputs = [ a2ps cups ghostscript ];
+
+  # wrapper script that links the relevant files to a writeable directory and
+  # calls the original executable
+  brprintconf_mfcj625dw_script = ''
+    #!${runtimeShell}
+    cd $(mktemp -d)
+    cp @out@/bin/brprintconf_mfcj625dw_patched brprintconf_mfcj625dw_patched
+    cp @out@/opt/brother/Printers/mfcj625dw/inf/brmfcj625dwfunc brmfcj625dwfunc
+    cp @out@/opt/brother/Printers/mfcj625dw/inf/brmfcj625dwrc brmfcj625dwrc
+    ./brprintconf_mfcj625dw_patched "$@"
+  '';
+
+  unpackPhase = ''
+    dpkg-deb -x $src $out
+  '';
+
+  patchPhase = ''
+    substituteInPlace $out/opt/brother/Printers/mfcj625dw/lpd/filtermfcj625dw \
+        --replace /opt "$out/opt"
+    substituteInPlace $out/opt/brother/Printers/mfcj625dw/lpd/psconvertij2 \
+        --replace "GHOST_SCRIPT=\`which gs\`" "GHOST_SCRIPT=gs"
+    substituteInPlace $out/opt/brother/Printers/mfcj625dw/inf/setupPrintcapij \
+      --replace "/opt/brother/Printers" "$out/opt/brother/Printers" \
+      --replace "printcap.local" "printcap"
+
+    # replace "/opt/brother/Printers/%s/inf/br%sfunc" with "brmfcj625dwfunc" and
+    # replace "/opt/brother/Printers/%s/inf/br%src" with "brmfcj625dwrc"
+    mkdir $out/bin
+    ${util-linux}/bin/hexdump -ve '1/1 "%.2x"' $out/usr/bin/brprintconf_mfcj625dw | \
+        sed 's/2f6f70742f62726f746865722f5072696e746572732f25732f696e662f6272257366756e63/62726d66636a363235647766756e6300000000000000000000000000000000000000000000/' | \
+        sed 's/2f6f70742f62726f746865722f5072696e746572732f25732f696e662f627225737263/62726d66636a3632356477726300000000000000000000000000000000000000000000/' | \
+        ${xxd}/bin/xxd -r -p > $out/bin/brprintconf_mfcj625dw_patched
+    chmod +x $out/bin/brprintconf_mfcj625dw_patched
+  '';
+
+  installPhase = ''
+    wrapProgram $out/opt/brother/Printers/mfcj625dw/lpd/psconvertij2 \
+        --prefix PATH : ${stdenv.lib.makeBinPath [
+          coreutils
+          ghostscript
+          gnused
+        ]}
+    wrapProgram $out/opt/brother/Printers/mfcj625dw/lpd/filtermfcj625dw \
+        --prefix PATH : ${stdenv.lib.makeBinPath [
+          a2ps
+          coreutils
+          file
+          ghostscript
+          gnused
+        ]}
+
+    # we masquerade our wrapper script as a binary of the same name
+    echo "$brprintconf_mfcj625dw_script" > $out/bin/brprintconf_mfcj625dw
+    chmod +x $out/bin/brprintconf_mfcj625dw
+    substituteInPlace $out/bin/brprintconf_mfcj625dw --replace "@out@" "$out"
+
+    mkdir -p $out/lib/cups/filter
+    ln -s $out/opt/brother/Printers/mfcj625dw/lpd/filtermfcj625dw \
+        $out/lib/cups/filter/brother_lpdwrapper_mfcj625dw
+  '';
+
+  meta = {
+    description = "Brother MFC-J625DW lpr driver";
+    homepage = "https://global.brother";
+    license = stdenv.lib.licenses.unfree;
+    platforms = stdenv.lib.platforms.linux;
+    downloadPage = "https://support.brother.com/g/b/downloadlist.aspx?c=sg&lang=en&prod=mfcj625dw_all&os=128";
+    maintainers = stdenv.lib.maintainers.chuahou;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29085,6 +29085,8 @@ in
 
   hll2390dw-cups = callPackage ../misc/cups/drivers/hll2390dw-cups { };
 
+  mfcj625dwlpr = pkgsi686Linux.callPackage ../misc/cups/drivers/mfcj625dwlpr { };
+
   mfcj470dw-cupswrapper = callPackage ../misc/cups/drivers/mfcj470dwcupswrapper { };
   mfcj470dwlpr = pkgsi686Linux.callPackage ../misc/cups/drivers/mfcj470dwlpr { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29085,6 +29085,7 @@ in
 
   hll2390dw-cups = callPackage ../misc/cups/drivers/hll2390dw-cups { };
 
+  mfcj625dwcupswrapper = callPackage ../misc/cups/drivers/mfcj625dwcupswrapper { };
   mfcj625dwlpr = pkgsi686Linux.callPackage ../misc/cups/drivers/mfcj625dwlpr { };
 
   mfcj470dw-cupswrapper = callPackage ../misc/cups/drivers/mfcj470dwcupswrapper { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
